### PR TITLE
Flip graph

### DIFF
--- a/osm-jigsaw-api/README.md
+++ b/osm-jigsaw-api/README.md
@@ -98,7 +98,7 @@ Returns the OSM tags for an OSM id associated with an area from the graph.
 
 #### Execution
 
-A full planet graph fits within a 54Gb heap (was 30 until the new graph format)
+A 2023 full planet graph with 15 million areas fits in a 64Gb heap.
 
 ```
 sbt -mem 54000 run

--- a/osm-jigsaw-api/app/graph/GraphReader.scala
+++ b/osm-jigsaw-api/app/graph/GraphReader.scala
@@ -1,72 +1,57 @@
 package graph
 
-import java.io.{BufferedInputStream, FileNotFoundException}
-import java.net.URL
-
-import javax.inject.Inject
 import model.{GraphNode, OsmIdParsing}
-import outputgraphnode.OutputGraphNode
+import outputgraphnodev2.OutputGraphNodeV2
 import play.api.Logger
 import progress.ProgressCounter
 
+import java.io.{BufferedInputStream, FileNotFoundException}
+import java.net.URL
+import javax.inject.Inject
 import scala.collection.mutable
 
 class GraphReader @Inject()(areasReader: AreasReader) extends OsmIdParsing {
 
   def loadGraph(graphFile: URL): Option[GraphNode] = {
     try {
-      def toGraphNode(ogn: OutputGraphNode): Option[GraphNode] = {
-        val maybeNode = ogn.area.flatMap { areaId =>
-          areasReader.getAreas().get(areaId).map { area =>
-            GraphNode(area = area)
-          }
-        }
-        if (maybeNode.isEmpty) {
-          Logger.warn("No area found for " + ogn)
-        }
-        maybeNode
-      }
 
-      val stack = mutable.Stack[GraphNode]()
+      val nodes = mutable.Map[Long, GraphNode]()
+
+      def toGraphNode(ogn: OutputGraphNodeV2): GraphNode = {
+        val area = areasReader.getAreas()(ogn.area)
+        // Map the children; leaf nodes appear first in the input file so will always have been created before been referenced
+        val children = ogn.children.map { childId =>
+          nodes(childId)
+        }
+        GraphNode(area = area, children = children)
+      }
 
       try {
         val input = new BufferedInputStream(graphFile.openStream())
 
-        val counterSecond = new ProgressCounter(step = 10000, label = Some("Building graph"))
+        val counterSecond = new ProgressCounter(step = 100, label = Some("Reading graph"))
         var ok = true
+
+        var root: GraphNode = null
         while (ok) {
           counterSecond.withProgress {
-            ok = OutputGraphNode.parseDelimitedFrom(input).flatMap { oa =>
-              toGraphNode(oa).map { node =>
-                val insertInto = if (stack.nonEmpty) {
-                  var insertInto = stack.pop
-                  while (!oa.parent.contains(insertInto.area.id)) {
-                    insertInto = stack.pop
-                  }
-                  insertInto.children += node
-                  insertInto
-                } else {
-                  node
-                }
-
-                stack.push(insertInto)
-                stack.push(node)
-                node
-              }
+            ok = OutputGraphNodeV2.parseDelimitedFrom(input).map { oa =>
+              val node = toGraphNode(oa)
+              root = node
+              node
             }.nonEmpty
           }
         }
         input.close()
 
         Logger.info("Finished reading")
-        Logger.info("Head node is: " + stack.lastOption.map(_.area.id))
-        stack.lastOption
+        Logger.info("Head node is: " + root.area.id)
+        Some(root)
 
       } catch {
-        case _: FileNotFoundException => {
+        case _: FileNotFoundException =>
           Logger.warn("No segment found")
           None
-        }
         case e: Exception =>
           throw e
       }

--- a/osm-jigsaw-api/app/graph/GraphService.scala
+++ b/osm-jigsaw-api/app/graph/GraphService.scala
@@ -26,7 +26,7 @@ class GraphService @Inject()(configuration: Configuration, tagService: TagServic
     val dataUrl = configuration.getString("data.url").get
     val extractName = configuration.getString("extract.name").get
     //val segmentURL = new URL(dataUrl + "/" + extractName + "/" + extractName + ".graph." + geohash.toBase32 + ".pbf")
-    val segmentURL = new URL(dataUrl + "/" + extractName + "/" + extractName + ".graph.pbf")
+    val segmentURL = new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2.pbf")
 
     val cacheKey = segmentURL.toExternalForm
     val cached = segmentCache.getIfPresent(cacheKey)

--- a/osm-jigsaw-api/app/model/Model.scala
+++ b/osm-jigsaw-api/app/model/Model.scala
@@ -7,7 +7,7 @@ case class Area(id: Long, points: Seq[Point], osmIds: Seq[OsmId], area: Double) 
 
 case class Point(lat: Double, lon: Double)
 case class OsmId(id: Long, `type`: Char)
-case class GraphNode(area: Area, children: mutable.ListBuffer[GraphNode] = mutable.ListBuffer())
+case class GraphNode(area: Area, children: Seq[GraphNode] = mutable.ListBuffer())
 
 case class OutputEntity(osmId: String, name: String)
 case class OutputNode(id: Long, entities: Seq[OutputEntity], children: Long, area: Double)

--- a/osm-jigsaw-api/conf/application.conf
+++ b/osm-jigsaw-api/conf/application.conf
@@ -1,4 +1,4 @@
-data.url="https://storage.googleapis.com/osm-jigsaw"
-extract.name="malta-191226"
+data.url="file:///Users/tony/git/osm-jigsaw/osm-jigsaw-api"
+extract.name="new-zealand-230705"
 
 play.http.secret.key="changeme"

--- a/osm-jigsaw-api/src/protobuf/outputgraphnodev2.proto
+++ b/osm-jigsaw-api/src/protobuf/outputgraphnodev2.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+message OutputGraphNodeV2 {
+   required int64 area = 1;
+   repeated int64 children = 2 [packed=true];
+}

--- a/osm-jigsaw-parser/go.bash
+++ b/osm-jigsaw-parser/go.bash
@@ -1,15 +1,16 @@
+input="dorset-230715"
+
 # exit when any command fails
 set -e
 
-#input="great-britain-230704"
-input="ireland-and-northern-ireland-180717"
-input="malta-230704"
+mkdir -p $input
 
 jarfile="osm-jigsaw-parser-assembly-1.0.jar"
-
-#java -jar $jarfile -s boundaries $input
-#java -Xmx8G -jar $jarfile -s extract $input
-#java -Xmx8G -jar $jarfile -s areaways $input
-#java -Xmx8G -jar $jarfile -s areas $input
+java -jar $jarfile -s boundaries $input
+java -Xmx8G -jar $jarfile -s extract $input
+java -Xmx8G -jar $jarfile -s areaways $input
+java -Xmx8G -jar $jarfile -s areas $input
 time java -Xmx8G -jar $jarfile -s graph $input
-#java -jar $jarfile -s tags $input 
+java -jar $jarfile -s tags $input 
+java -jar $jarfile -s flip $input
+

--- a/osm-jigsaw-parser/src/main/protobuf/outputgraphnodev2.proto
+++ b/osm-jigsaw-parser/src/main/protobuf/outputgraphnodev2.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+message OutputGraphNodeV2 {
+   required int64 area = 1;
+   repeated int64 children = 2 [packed=true];
+}

--- a/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
+++ b/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
@@ -13,7 +13,11 @@ trait OutputFiles {
   }
 
   def graphFile(extractName: String) = {
-    outputFolderFor(extractName) + "/" + extractName + ".graph." + ".pbf"
+    outputFolderFor(extractName) + "/" + extractName + ".graph" + ".pbf"
+  }
+
+  def graphV2File(extractName: String) = {
+    outputFolderFor(extractName) + "/" + extractName + ".graphv2" + ".pbf"
   }
 
   def tagsFilePath(extractName: String): String = {

--- a/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
+++ b/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
@@ -13,7 +13,7 @@ trait OutputFiles {
   }
 
   def graphFile(extractName: String) = {
-    outputFolderFor(extractName) + "/" + extractName + ".graph" + ".pbf"
+      extractName + ".graph" + ".pbf"
   }
 
   def graphV2File(extractName: String) = {

--- a/osm-jigsaw-viewer/app/controllers/Application.scala
+++ b/osm-jigsaw-viewer/app/controllers/Application.scala
@@ -79,7 +79,7 @@ class Application @Inject()(configuration: Configuration, ws: WSClient, cc: Cont
   }
 
   def click(lat: Double, lon: Double) = Action.async { request =>
-    val reverseApiCallUrl = Url.parse(apiUrl + "/reverse").addParam("lat", lat).addParam("lon", lon)
+    val reverseApiCallUrl = Url.parse(apiUrl + "/reverse").addParam("lat", lat.toString).addParam("lon", lon.toString)
     val eventualCrumbs = ws.url(reverseApiCallUrl.toString).get.map { r =>
       implicit val er = Json.reads[Entity]
       implicit val gnr = Json.reads[GraphNode]
@@ -88,7 +88,7 @@ class Application @Inject()(configuration: Configuration, ws: WSClient, cc: Cont
       }
     }
 
-    val nameApiCallUrl = Url.parse(apiUrl + "/name").addParam("lat", lat).addParam("lon", lon)
+    val nameApiCallUrl = Url.parse(apiUrl + "/name").addParam("lat", lat.toString).addParam("lon", lon.toString)
     val eventualName = ws.url(nameApiCallUrl.toString).get.map { r =>
       Json.parse(r.body).as[String]
     }

--- a/osm-jigsaw-viewer/build.sbt
+++ b/osm-jigsaw-viewer/build.sbt
@@ -5,9 +5,8 @@ lazy val `osm-jigsaw-viewer` = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := "2.12.13"
 
-libraryDependencies ++= Seq(ws)
-libraryDependencies += "io.lemonlabs" %% "scala-uri" % "3.6.0"
-libraryDependencies += guice
+libraryDependencies ++= Seq(ws, guice)
+libraryDependencies += "io.lemonlabs" %% "scala-uri" % "1.5.1"
 
 libraryDependencies += specs2 % Test
 

--- a/osm-jigsaw-viewer/project/build.properties
+++ b/osm-jigsaw-viewer/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/osm-jigsaw-viewer/project/plugins.sbt
+++ b/osm-jigsaw-viewer/project/plugins.sbt
@@ -1,5 +1,1 @@
-//logLevel := Level.Warn
-
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
-
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")


### PR DESCRIPTION
Flip the graph from nodes with parents to nodes with children.

Nodes with children graph format allows us to fit 2023 full planet into a 64Gb heap.

Makes it alot easier to read in. Allows us to sparely populate duplicate nodes so big size and memory savings for the consumer.

Reduces the size of planet graph from ~6Gb to 170Mb.