### PR TITLE
Tilted outout

### DIFF
--- a/osm-jigsaw-api/app/areas/AreaComparison.scala
+++ b/osm-jigsaw-api/app/areas/AreaComparison.scala
@@ -27,7 +27,7 @@ trait AreaComparison extends BoundingBox {
     def polygonForNode(node: GraphNode): Option[Polygon] = {
       val key = node.area.id
       Option(polygonCache.getIfPresent(key)).fold {
-        Logger.info("Cache miss for area polygon: " + key)
+        Logger.debug("Cache miss for area polygon: " + key)
         buildPolygonForPoints(node.area.points).map { p =>
           polygonCache.put(key, p)
           p

--- a/osm-jigsaw-api/app/controllers/Application.scala
+++ b/osm-jigsaw-api/app/controllers/Application.scala
@@ -104,7 +104,7 @@ class Application @Inject()(configuration: Configuration, graphService: GraphSer
   // Given an OSM id return it's tags as a map
   def tags(osmId: String) = Action.async { request =>
     val id = toOsmId(osmId)
-    val tags = graphService.tagsFor(id).getOrElse(Map())
+    val tags = tagService.tagsFor(id).getOrElse(Map())
     Future.successful(Ok(Json.toJson(tags)))
   }
 

--- a/osm-jigsaw-api/app/controllers/Application.scala
+++ b/osm-jigsaw-api/app/controllers/Application.scala
@@ -1,22 +1,21 @@
 package controllers
 
-import javax.inject.Inject
-
 import areas.BoundingBox
 import com.esri.core.geometry.Point
 import graph.GraphService
 import model._
 import naming.NaiveNamingService
+import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, Controller}
-import play.api.{Configuration, Logger}
 import tags.{EntityNameTags, TagService}
 
+import javax.inject.Inject
 import scala.collection.mutable
 import scala.concurrent.Future
 
-class Application @Inject()(configuration: Configuration, graphService: GraphService, val tagService: TagService,
-                            naiveNamingService: NaiveNamingService) extends Controller with BoundingBox with OsmIdParsing with EntityNameTags {
+class Application @Inject()(graphService: GraphService, val tagService: TagService, naiveNamingService: NaiveNamingService)
+  extends Controller with BoundingBox with OsmIdParsing with EntityNameTags {
 
   // Given a location return all of sequences of overlapping areas which enclose it
   def reverse(lat: Double, lon: Double) = Action.async { request =>

--- a/osm-jigsaw-api/app/graph/AreasReader.scala
+++ b/osm-jigsaw-api/app/graph/AreasReader.scala
@@ -1,29 +1,19 @@
 package graph
 
-import java.io.BufferedInputStream
-import java.net.URL
-
-import javax.inject.Inject
 import model.{Area, OsmIdParsing, Point}
 import outputarea.OutputArea
 import play.api.{Configuration, Logger}
 import progress.ProgressCounter
 
+import java.io.BufferedInputStream
+import java.net.URL
+import javax.inject.Inject
 import scala.collection.mutable
 
 class AreasReader @Inject()(configuration: Configuration) extends OsmIdParsing {
 
-  private val areas = {
-    val dataUrl = configuration.getString("data.url").get
-    val extractName = configuration.getString("extract.name").get
-    val areasFile = new URL(dataUrl + "/" + extractName + "/" + extractName + ".areas.pbf")
-    Logger.info("Loading areas from: " + areasFile)
-    loadAreas(areasFile)
-  }
-
-  def getAreas(): Map[Long, Area] = areas
-
-  private def loadAreas(areasFile: URL): Map[Long, Area] = {
+  def loadAreas(areasFile: URL): Map[Long, Area] = {
+    Logger.info("Loading areas from: " + areasFile.toExternalForm)
 
     def outputAreaToArea(oa: OutputArea): Option[Area] = {
       oa.id.flatMap { id =>

--- a/osm-jigsaw-api/app/graph/GraphReader.scala
+++ b/osm-jigsaw-api/app/graph/GraphReader.scala
@@ -1,6 +1,6 @@
 package graph
 
-import model.{Area, GraphNode, OsmIdParsing}
+import model.{GraphNode, OsmIdParsing}
 import outputgraphnodev2.OutputGraphNodeV2
 import play.api.Logger
 import progress.ProgressCounter
@@ -31,7 +31,7 @@ class GraphReader @Inject()(areasReader: AreasReader) extends OsmIdParsing {
       try {
         val input = new BufferedInputStream(graphFile.openStream())
 
-        val counterSecond = new ProgressCounter(step = 100, label = Some("Reading graph"))
+        val counterSecond = new ProgressCounter(step = 1000, label = Some("Reading graph"))
         var ok = true
 
         var root: GraphNode = null

--- a/osm-jigsaw-api/app/graph/GraphReader.scala
+++ b/osm-jigsaw-api/app/graph/GraphReader.scala
@@ -1,6 +1,6 @@
 package graph
 
-import model.{GraphNode, OsmIdParsing}
+import model.{Area, GraphNode, OsmIdParsing}
 import outputgraphnodev2.OutputGraphNodeV2
 import play.api.Logger
 import progress.ProgressCounter
@@ -12,13 +12,15 @@ import scala.collection.mutable
 
 class GraphReader @Inject()(areasReader: AreasReader) extends OsmIdParsing {
 
-  def loadGraph(graphFile: URL): Option[GraphNode] = {
+  def loadGraph(graphFile: URL, areasFile: URL): Option[GraphNode] = {
     try {
+      // Load areas
+      val areas = areasReader.loadAreas(areasFile)
 
+      // Load graph
       val nodes = mutable.Map[Long, GraphNode]()
-
       def toGraphNode(ogn: OutputGraphNodeV2): GraphNode = {
-        val area = areasReader.getAreas()(ogn.area)
+        val area = areas(ogn.area)
         // Map the children; leaf nodes appear first in the input file so will always have been created before been referenced
         val children = ogn.children.map { childId =>
           nodes(childId)

--- a/osm-jigsaw-api/app/graph/GraphService.scala
+++ b/osm-jigsaw-api/app/graph/GraphService.scala
@@ -12,17 +12,17 @@ import javax.inject.Inject
 
 class GraphService @Inject()(configuration: Configuration, areasReader: AreasReader, val polygonCache: PolygonCache) extends AreaComparison {
 
-  val geohashResolution = 2
+  private val dataUrl = configuration.getString("data.url").get
+  private val extractName = configuration.getString("extract.name").get
 
-  val segmentCache = CacheBuilder.newBuilder()
+  private val geohashResolution = 3
+
+  private val segmentCache = CacheBuilder.newBuilder()
     .maximumSize(10)
     .build[String, GraphNode]
 
   def headOfGraphCoveringThisPoint(point: Point): Option[GraphNode] = {
     val geohash = GeoHash.withCharacterPrecision(point.getX, point.getY, geohashResolution)
-
-    val dataUrl = configuration.getString("data.url").get
-    val extractName = configuration.getString("extract.name").get
 
     val graphFileURL = if (geohashResolution > 0 ) {
       new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2-" + geohash.toBase32 + ".pbf")

--- a/osm-jigsaw-api/app/graph/GraphService.scala
+++ b/osm-jigsaw-api/app/graph/GraphService.scala
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class GraphService @Inject()(configuration: Configuration, tagService: TagService, areasReader: AreasReader, val polygonCache: PolygonCache) extends AreaComparison {
 
-  val geohashCharacters = 4
+  val geohashResolution = 2
 
   val segmentCache = CacheBuilder.newBuilder()
     .maximumSize(10)
@@ -21,12 +21,16 @@ class GraphService @Inject()(configuration: Configuration, tagService: TagServic
 
 
   def headOfGraphCoveringThisPoint(point: Point): Option[GraphNode] = {
-    val geohash = GeoHash.withCharacterPrecision(point.getX, point.getY, geohashCharacters)
+    val geohash = GeoHash.withCharacterPrecision(point.getX, point.getY, geohashResolution)
 
     val dataUrl = configuration.getString("data.url").get
     val extractName = configuration.getString("extract.name").get
-    //val segmentURL = new URL(dataUrl + "/" + extractName + "/" + extractName + ".graph." + geohash.toBase32 + ".pbf")
-    val segmentURL = new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2.pbf")
+
+    val segmentURL = if (geohashResolution > 0 ) {
+      new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2-" + geohash.toBase32 + ".pbf")
+    } else {
+      new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2.pbf")
+    }
 
     val cacheKey = segmentURL.toExternalForm
     val cached = segmentCache.getIfPresent(cacheKey)

--- a/osm-jigsaw-api/app/graph/GraphService.scala
+++ b/osm-jigsaw-api/app/graph/GraphService.scala
@@ -91,21 +91,22 @@ class GraphService @Inject()(configuration: Configuration, areasReader: AreasRea
 
   // TODO dog pile protection here
   private def loadGraphFor(point: Point, geohash: GeoHash): Future[Option[GraphNode]] = {
-    val graphFileURL = if (geohashResolution > 0) {
-      new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2-" + geohash.toBase32 + ".pbf")
-    } else {
-      new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2.pbf")
-    }
+    Future.successful {
+      val graphFileURL = if (geohashResolution > 0) {
+        new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2-" + geohash.toBase32 + ".pbf")
+      } else {
+        new URL(dataUrl + "/" + extractName + "/" + extractName + ".graphv2.pbf")
+      }
 
-    val areasFileURL = if (geohashResolution > 0) {
-      new URL(dataUrl + "/" + extractName + "/" + extractName + ".areas-" + geohash.toBase32 + ".pbf")
-    } else {
-      new URL(dataUrl + "/" + extractName + "/" + extractName + ".areas.pbf")
-    }
+      val areasFileURL = if (geohashResolution > 0) {
+        new URL(dataUrl + "/" + extractName + "/" + extractName + ".areas-" + geohash.toBase32 + ".pbf")
+      } else {
+        new URL(dataUrl + "/" + extractName + "/" + extractName + ".areas.pbf")
+      }
 
-    Logger.info("Loading graph segment from " + graphFileURL + " for point " + point)
-    val maybeNode = new GraphReader(areasReader).loadGraph(graphFileURL, areasFileURL)
-    Future.successful(maybeNode)
+      Logger.info("Loading graph segment from " + graphFileURL + " for point " + point)
+      new GraphReader(areasReader).loadGraph(graphFileURL, areasFileURL)
+    }
   }
 
 }

--- a/osm-jigsaw-api/app/graph/GraphService.scala
+++ b/osm-jigsaw-api/app/graph/GraphService.scala
@@ -18,7 +18,6 @@ class GraphService @Inject()(configuration: Configuration, areasReader: AreasRea
     .maximumSize(10)
     .build[String, GraphNode]
 
-
   def headOfGraphCoveringThisPoint(point: Point): Option[GraphNode] = {
     val geohash = GeoHash.withCharacterPrecision(point.getX, point.getY, geohashResolution)
 
@@ -55,7 +54,7 @@ class GraphService @Inject()(configuration: Configuration, areasReader: AreasRea
     }
   }
 
-  def pathsDownTo(pt: Point): Seq[Seq[GraphNode]] = {
+  def pathsDownTo(point: Point): Seq[Seq[GraphNode]] = {
 
     def nodesContaining(pt: Point, node: GraphNode, stack: Seq[GraphNode]): Seq[Seq[GraphNode]] = {
       val matchingChildren = node.children.filter { c =>
@@ -71,8 +70,8 @@ class GraphService @Inject()(configuration: Configuration, areasReader: AreasRea
       }
     }
 
-    headOfGraphCoveringThisPoint(pt).map { head =>
-      val containing = nodesContaining(pt, head, Seq())
+    headOfGraphCoveringThisPoint(point).map { head =>
+      val containing = nodesContaining(point, head, Seq())
       val withoutRoot = containing.map(r => r.drop(1)).filter(_.nonEmpty)
       withoutRoot
 

--- a/osm-jigsaw-api/app/graph/GraphService.scala
+++ b/osm-jigsaw-api/app/graph/GraphService.scala
@@ -4,14 +4,13 @@ import areas.{AreaComparison, PolygonCache}
 import ch.hsr.geohash.GeoHash
 import com.esri.core.geometry.Point
 import com.google.common.cache.CacheBuilder
-import model.{GraphNode, OsmId}
+import model.GraphNode
 import play.api.{Configuration, Logger}
-import tags.TagService
 
 import java.net.URL
 import javax.inject.Inject
 
-class GraphService @Inject()(configuration: Configuration, tagService: TagService, areasReader: AreasReader, val polygonCache: PolygonCache) extends AreaComparison {
+class GraphService @Inject()(configuration: Configuration, areasReader: AreasReader, val polygonCache: PolygonCache) extends AreaComparison {
 
   val geohashResolution = 2
 
@@ -80,10 +79,6 @@ class GraphService @Inject()(configuration: Configuration, tagService: TagServic
     }.getOrElse {
       Seq.empty
     }
-  }
-
-  def tagsFor(osmId: OsmId): Option[Map[String, String]] = {
-    tagService.tagsFor(osmId)
   }
 
 }

--- a/osm-jigsaw-api/app/naming/NaiveNamingService.scala
+++ b/osm-jigsaw-api/app/naming/NaiveNamingService.scala
@@ -3,6 +3,7 @@ package naming
 import javax.inject.Inject
 import model.OsmId
 import tags.TagService
+import com.esri.core.geometry.Point
 
 import scala.collection.mutable
 
@@ -27,10 +28,10 @@ class NaiveNamingService @Inject()(tagService: TagService) {
     "type" -> "toll"
   )
 
-  def nameFor(paths: Seq[Seq[(Seq[OsmId], Double)]], requestedLanguage: Option[String] = None): String = {
+  def nameFor(paths: Seq[Seq[(Seq[OsmId], Double)]], point: Point, requestedLanguage: Option[String] = None): String = {
 
     def hasExcludedTags(osmId: OsmId): Boolean = {
-      val osmIdTags = tagService.tagsFor(osmId).getOrElse(Map.empty).toSet
+      val osmIdTags = tagService.tagsFor(osmId, point).getOrElse(Map.empty).toSet
       val excludedTags = osmIdTags.intersect(TagsWhichDoNotContributeToLocationNames)
       excludedTags.nonEmpty
     }
@@ -85,7 +86,7 @@ class NaiveNamingService @Inject()(tagService: TagService) {
     }
 
     val names = sortedByArea.map { n =>
-      tagService.nameForOsmId(n, requestedLanguage)
+      tagService.nameForOsmId(n, point, requestedLanguage)
     }.flatten
 
 

--- a/osm-jigsaw-api/app/tags/TagService.scala
+++ b/osm-jigsaw-api/app/tags/TagService.scala
@@ -1,102 +1,83 @@
 package tags
 
-import java.io.BufferedInputStream
-import java.net.URL
-import javax.inject.{Inject, Singleton}
-
+import com.google.common.cache.CacheBuilder
 import model.{OsmId, OsmIdParsing}
 import outputtagging.OutputTagging
 import play.api.{Configuration, Logger}
 import progress.ProgressCounter
 
-import scala.collection.{immutable, mutable}
+import java.io.BufferedInputStream
+import java.net.URL
+import javax.inject.{Inject, Singleton}
+import scala.collection.mutable
 
 @Singleton
 class TagService @Inject()(configuration: Configuration) extends OsmIdParsing with EntityNameTags {
 
-  val tagsFile = {
-    val dataUrl = configuration.getString("data.url").get
-    val extractName = configuration.getString("extract.name").get
-    new URL(dataUrl + "/" + extractName + "/" + extractName + ".tags.pbf")
-  }
-
-  val tagsMap: (Map[OsmId, Seq[(Int, String)]], immutable.IndexedSeq[String]) = loadTags(tagsFile)
+  val tagsCache = CacheBuilder.newBuilder()
+    .maximumSize(10)
+    .build[String, Map[OsmId, Map[String, String]]]
 
   val English = "en"
 
   def tagsFor(osmId: OsmId): Option[Map[String, String]] = {
-    val keysIndex = tagsMap._2    // TODO push up
-
-    tagsMap._1.get(osmId).map { i =>
-      i.map( j => (keysIndex(j._1), j._2)).toMap
+    val tagsFileURL = {
+      val dataUrl = configuration.getString("data.url").get
+      val extractName = configuration.getString("extract.name").get
+      new URL(dataUrl + "/" + extractName + "/" + extractName + ".tags.pbf")
     }
+
+    val cached = tagsCache.getIfPresent(tagsFileURL.toExternalForm)
+    val maybeTagsForSegment = Option(cached).map { t =>
+      Logger.info("Cache hit for " + tagsFileURL.toExternalForm)
+      Some(t)
+    }.getOrElse {
+      val maybeTags = loadTags(tagsFileURL)
+      maybeTags.foreach{ t =>
+        tagsCache.put(tagsFileURL.toExternalForm, t)
+      }
+      maybeTags
+    }
+
+    maybeTagsForSegment.flatMap(_.get(osmId))
   }
 
-  def nameForOsmId(osmId: OsmId, encoding: Option[String] = None): Option[String] = {
+  def nameForOsmId(osmId: OsmId, encoding: Option[String] = None): Option[String] = { // TODO put another class
     tagsFor(osmId).flatMap { tags =>
       getNameFromTags(tags, encoding.getOrElse(English))
     }
   }
 
-  private def loadTags(tagsFile: URL): (Map[OsmId, Seq[(Int, String)]], immutable.IndexedSeq[String]) = {
+  private def loadTags(tagsFile: URL): Option[Map[OsmId, Map[String, String]]] = {
     try {
-      val uniqueKeys = mutable.Set[String]()
-
-      var totalKeys = 0
+      Logger.info("Reading tags")
+      val tagsMap = mutable.Map[OsmId, Map[String, String]]()
 
       val input = new BufferedInputStream(tagsFile.openStream())
-      val counter = new ProgressCounter(step = 10000, label = Some("Indexing tags"))
+      val counter = new ProgressCounter(step = 10000, label = Some("Reading tags"))
       var ok = true
       while (ok) {
         counter.withProgress {
           val outputTagging = OutputTagging.parseDelimitedFrom(input)
-          outputTagging.foreach { ot =>
+          outputTagging.map { ot =>
             val osmId = ot.osmId.get
             val keys = ot.keys
-
-            keys.map( k => uniqueKeys.add(k))
-            totalKeys = totalKeys + keys.size
+            val values = ot.values
+            val tuples = keys.zip(values).toMap
+            tagsMap.put(toOsmId(osmId), tuples)
           }
           ok = outputTagging.nonEmpty
         }
       }
       input.close()
 
-      Logger.info("Found " + totalKeys + " keys of which " + uniqueKeys.size + " were unique")
-
-      Logger.info("Building key and value index maps")
-      val keysSeq = uniqueKeys.toIndexedSeq
-
-      val keysIndex: Map[String, Int] = keysSeq.zipWithIndex.toMap
-
-      Logger.info("Rereading tags after indexing")
-      val tagsMap = mutable.Map[OsmId, Seq[(Int, String)]]()
-
-      val input2 = new BufferedInputStream(tagsFile.openStream())
-      val counter2 = new ProgressCounter(step = 10000, label = Some("Reading tags"))
-      ok = true
-      while (ok) {
-        counter2.withProgress {
-          val outputTagging = OutputTagging.parseDelimitedFrom(input2)
-          outputTagging.map { ot =>
-            val osmId = ot.osmId.get
-            val keys = ot.keys.map(k => keysIndex.get(k).get)
-            val values = ot.values
-            val tuples = keys.zip(values).toArray
-            tagsMap.put(toOsmId(osmId), tuples)
-        }
-          ok = outputTagging.nonEmpty
-        }
-      }
-      input2.close()
-
       Logger.info("Read " + tagsMap.size + " taggings")
-      (tagsMap.toMap, keysSeq)
+      Some(tagsMap.toMap)
 
     } catch {
       case e: Exception =>
         Logger.error("Error: " + e)
-        throw e
+        None
     }
   }
 

--- a/osm-jigsaw-api/app/tags/TagService.scala
+++ b/osm-jigsaw-api/app/tags/TagService.scala
@@ -38,7 +38,7 @@ class TagService @Inject()(configuration: Configuration) extends OsmIdParsing wi
 
     val cached = tagsCache.getIfPresent(tagsFileURL.toExternalForm)
     val maybeTagsForSegment = Option(cached).map { t =>
-      Logger.info("Cache hit for " + tagsFileURL.toExternalForm)
+      Logger.debug("Cache hit for " + tagsFileURL.toExternalForm)
       Some(t)
     }.getOrElse {
       val maybeTags = loadTags(tagsFileURL)

--- a/osm-jigsaw-api/build.sbt
+++ b/osm-jigsaw-api/build.sbt
@@ -21,5 +21,5 @@ dockerExposedPorts in Docker := Seq(9000)
 
 javaOptions in Universal ++= Seq(
   // -J params will be added as jvm parameters
-  "-J-XshowSettings:vm", "-J-XX:+PrintCommandLineFlags", "-J-XX:+UseConcMarkSweepGC", "-J-XX:MaxRAMPercentage=100"
+  "-J-XshowSettings:vm", "-J-XX:+PrintCommandLineFlags", "-J-XX:+UseConcMarkSweepGC", "-J-XX:MaxRAMPercentage=90"
 )

--- a/osm-jigsaw-api/conf/application.conf
+++ b/osm-jigsaw-api/conf/application.conf
@@ -1,5 +1,5 @@
-data.url="file:///Users/tony/git/osm-jigsaw/osm-jigsaw-api"
-extract.name="new-zealand-230705"
+data.url="file:///Users/tony/git/osm-jigsaw/osm-jigsaw-parser/"
+extract.name="malta-230704"
 
 polygonCache.size=200000
 

--- a/osm-jigsaw-api/conf/routes
+++ b/osm-jigsaw-api/conf/routes
@@ -1,8 +1,7 @@
-GET     /tags       controllers.Application.tags(osm_id: String)
-
 GET     /reverse    controllers.Application.reverse(lat: Double, lon: Double)
 GET     /name       controllers.Application.name(lat: Double, lon: Double)
 GET     /show       controllers.Application.show(q: String, lat: Double, lon: Double)
+GET     /tags       controllers.Application.tags(osm_id: String, lat: Double, lon: Double)
 GET     /points     controllers.Application.points(q: String, lat: Double, lon: Double)
 
 GET     /healthz    controllers.Application.ping()

--- a/osm-jigsaw-api/test/naming/NaiveNamingServiceSpec.scala
+++ b/osm-jigsaw-api/test/naming/NaiveNamingServiceSpec.scala
@@ -1,8 +1,9 @@
 package naming
 
+import com.esri.core.geometry.Point
 import model.OsmId
 import org.mockito.Matchers.any
-import org.mockito.Mockito
+import org.mockito.{Matchers, Mockito}
 import org.specs2.mutable._
 import tags.TagService
 
@@ -11,7 +12,7 @@ class NaiveNamingServiceSpec extends Specification {
   private val R = "R".charAt(0)
   private val W = "W".charAt(0)
 
-  "place name is a concatenation of the the enclosing area names" in {
+  "place name is a concatenation of the enclosing area names" in {
     val australia = OsmId(80500L, R)
     val westernAustralia = OsmId(2316598, R)
     val ngaanyatjarra = OsmId(8165171, R)
@@ -22,16 +23,18 @@ class NaiveNamingServiceSpec extends Specification {
       (Seq(ngaanyatjarra), 0D)
     ))
 
+    val point = new Point(0, 0)
+
     val tagServiceMock = org.mockito.Mockito.mock(classOf[TagService])
 
-    Mockito.when(tagServiceMock.nameForOsmId(australia, None)).thenReturn(Some("Australia"))
-    Mockito.when(tagServiceMock.nameForOsmId(westernAustralia, None)).thenReturn(Some("Western Australia"))
-    Mockito.when(tagServiceMock.nameForOsmId(ngaanyatjarra, None)).thenReturn(Some("Ngaanyatjarra Indigenous Protected Area"))
-    Mockito.when(tagServiceMock.tagsFor(any[OsmId])).thenReturn(None)
+    Mockito.when(tagServiceMock.nameForOsmId(australia, point, None)).thenReturn(Some("Australia"))
+    Mockito.when(tagServiceMock.nameForOsmId(westernAustralia, point, None)).thenReturn(Some("Western Australia"))
+    Mockito.when(tagServiceMock.nameForOsmId(ngaanyatjarra, point, None)).thenReturn(Some("Ngaanyatjarra Indigenous Protected Area"))
+    Mockito.when(tagServiceMock.tagsFor(any[OsmId], Matchers.eq(point))).thenReturn(None)
 
     val namingService = new NaiveNamingService(tagServiceMock)
 
-    val name = namingService.nameFor(paths)
+    val name = namingService.nameFor(paths, point)
 
     name must equalTo("Ngaanyatjarra Indigenous Protected Area, Western Australia, Australia")
   }
@@ -49,17 +52,19 @@ class NaiveNamingServiceSpec extends Specification {
       (Seq(douglas), 0D)
     ))
 
+    val point = new Point(0, 0)
+
     val tagServiceMock = org.mockito.Mockito.mock(classOf[TagService])
 
-    Mockito.when(tagServiceMock.nameForOsmId(isleOfManAdminBoundary, None)).thenReturn(Some("Isle of Man"))
-    Mockito.when(tagServiceMock.nameForOsmId(isleOfManIsland, None)).thenReturn(Some("Isle of Man"))
-    Mockito.when(tagServiceMock.nameForOsmId(middle, None)).thenReturn(Some("Middle"))
-    Mockito.when(tagServiceMock.nameForOsmId(douglas, None)).thenReturn(Some("Douglas"))
-    Mockito.when(tagServiceMock.tagsFor(any[OsmId])).thenReturn(None)
+    Mockito.when(tagServiceMock.nameForOsmId(isleOfManAdminBoundary, point, None)).thenReturn(Some("Isle of Man"))
+    Mockito.when(tagServiceMock.nameForOsmId(isleOfManIsland, point, None)).thenReturn(Some("Isle of Man"))
+    Mockito.when(tagServiceMock.nameForOsmId(middle, point, None)).thenReturn(Some("Middle"))
+    Mockito.when(tagServiceMock.nameForOsmId(douglas, point, None)).thenReturn(Some("Douglas"))
+    Mockito.when(tagServiceMock.tagsFor(any[OsmId], Matchers.eq(point))).thenReturn(None)
 
     val namingService = new NaiveNamingService(tagServiceMock)
 
-    val name = namingService.nameFor(paths)
+    val name = namingService.nameFor(paths, point)
 
     name must equalTo("Douglas, Middle, Isle of Man")
   }
@@ -83,27 +88,29 @@ class NaiveNamingServiceSpec extends Specification {
 
     val paths = Seq(mariposaPath, yosemitePath)
 
+    val point = new Point(0, 0)
+
     val tagServiceMock = org.mockito.Mockito.mock(classOf[TagService])
 
-    Mockito.when(tagServiceMock.nameForOsmId(unitedStates, None)).thenReturn(Some("United States of America"))
-    Mockito.when(tagServiceMock.nameForOsmId(california, None)).thenReturn(Some("California"))
-    Mockito.when(tagServiceMock.nameForOsmId(mariposaCounty, None)).thenReturn(Some("Mariposa County"))
-    Mockito.when(tagServiceMock.nameForOsmId(yosemite, None)).thenReturn(Some("Yosemite National Park"))
-    Mockito.when(tagServiceMock.tagsFor(any[OsmId])).thenReturn(None)
+    Mockito.when(tagServiceMock.nameForOsmId(unitedStates, point, None)).thenReturn(Some("United States of America"))
+    Mockito.when(tagServiceMock.nameForOsmId(california, point, None)).thenReturn(Some("California"))
+    Mockito.when(tagServiceMock.nameForOsmId(mariposaCounty, point, None)).thenReturn(Some("Mariposa County"))
+    Mockito.when(tagServiceMock.nameForOsmId(yosemite, point, None)).thenReturn(Some("Yosemite National Park"))
+    Mockito.when(tagServiceMock.tagsFor(any[OsmId], Matchers.eq(point))).thenReturn(None)
 
     val namingService = new NaiveNamingService(tagServiceMock)
 
-    val name = namingService.nameFor(paths)
+    val name = namingService.nameFor(paths, point)
 
     name must contain("Yosemite National Park")
   }
 
   "merging overlapping areas should preserve the ordering of nested areas" in {
     val unitedKingdom = OsmId(16689, R)
-    val england =OsmId(16137, R)
-    val southWestEngland =OsmId(151339, R)
-    val dorset =OsmId(375535, R)
-    val bournemouth =OsmId(42134, R)
+    val england = OsmId(16137, R)
+    val southWestEngland = OsmId(151339, R)
+    val dorset = OsmId(375535, R)
+    val bournemouth = OsmId(42134, R)
 
     val viaEnglandPath = Seq(
       (Seq(unitedKingdom), 0D),
@@ -119,17 +126,19 @@ class NaiveNamingServiceSpec extends Specification {
 
     val paths = Seq(viaEnglandPath, viaSouthWestEnglandPath)
 
+    val point = new Point(0, 0)
+
     val tagServiceMock = org.mockito.Mockito.mock(classOf[TagService])
-    Mockito.when(tagServiceMock.nameForOsmId(unitedKingdom, None)).thenReturn(Some("United Kingdom"))
-    Mockito.when(tagServiceMock.nameForOsmId(england, None)).thenReturn(Some("England"))
-    Mockito.when(tagServiceMock.nameForOsmId(southWestEngland, None)).thenReturn(Some("South West England"))
-    Mockito.when(tagServiceMock.nameForOsmId(dorset, None)).thenReturn(Some("Dorset"))
-    Mockito.when(tagServiceMock.nameForOsmId(bournemouth, None)).thenReturn(Some("Bournemouth"))
-    Mockito.when(tagServiceMock.tagsFor(any[OsmId])).thenReturn(None)
+    Mockito.when(tagServiceMock.nameForOsmId(unitedKingdom, point, None)).thenReturn(Some("United Kingdom"))
+    Mockito.when(tagServiceMock.nameForOsmId(england, point, None)).thenReturn(Some("England"))
+    Mockito.when(tagServiceMock.nameForOsmId(southWestEngland, point, None)).thenReturn(Some("South West England"))
+    Mockito.when(tagServiceMock.nameForOsmId(dorset, point, None)).thenReturn(Some("Dorset"))
+    Mockito.when(tagServiceMock.nameForOsmId(bournemouth, point, None)).thenReturn(Some("Bournemouth"))
+    Mockito.when(tagServiceMock.tagsFor(any[OsmId], Matchers.eq(point))).thenReturn(None)
 
     val namingService = new NaiveNamingService(tagServiceMock)
 
-    val name = namingService.nameFor(paths)
+    val name = namingService.nameFor(paths, point)
 
     name must equalTo("Bournemouth, Dorset, England, South West England, United Kingdom")
   }
@@ -147,21 +156,23 @@ class NaiveNamingServiceSpec extends Specification {
 
     val paths = Seq(path)
 
+    val point = new Point(0, 0)
+
     val tagServiceMock = org.mockito.Mockito.mock(classOf[TagService])
-    Mockito.when(tagServiceMock.nameForOsmId(ireland, None)).thenReturn(Some("Ireland"))
-    Mockito.when(tagServiceMock.nameForOsmId(dublinCity1954, None)).thenReturn(Some("Dublin City 1953"))
-    Mockito.when(tagServiceMock.nameForOsmId(dublin, None)).thenReturn(Some("Dublin"))
+    Mockito.when(tagServiceMock.nameForOsmId(ireland, point, None)).thenReturn(Some("Ireland"))
+    Mockito.when(tagServiceMock.nameForOsmId(dublinCity1954, point, None)).thenReturn(Some("Dublin City 1953"))
+    Mockito.when(tagServiceMock.nameForOsmId(dublin, point, None)).thenReturn(Some("Dublin"))
 
-    Mockito.when(tagServiceMock.tagsFor(any[OsmId])).thenReturn(None)
+    Mockito.when(tagServiceMock.tagsFor(any[OsmId], Matchers.eq(point))).thenReturn(None)
 
-    val historicTags = Map[String, String]{
+    val historicTags = Map[String, String] {
       "historic" -> "yes"
     }
-    Mockito.when(tagServiceMock.tagsFor(OsmId(6741826, R))).thenReturn(Some(historicTags))
+    Mockito.when(tagServiceMock.tagsFor(OsmId(6741826, R), point)).thenReturn(Some(historicTags))
 
     val namingService = new NaiveNamingService(tagServiceMock)
 
-    val name = namingService.nameFor(paths)
+    val name = namingService.nameFor(paths, point)
 
     name must equalTo("Dublin, Ireland")
   }
@@ -184,28 +195,30 @@ class NaiveNamingServiceSpec extends Specification {
 
     val paths = Seq(normalPath, outlinerPath)
 
+    val point = new Point(0, 0)
+
     val tagServiceMock = org.mockito.Mockito.mock(classOf[TagService])
-    Mockito.when(tagServiceMock.nameForOsmId(spain, None)).thenReturn(Some("Spain"))
-    Mockito.when(tagServiceMock.nameForOsmId(andalusia, None)).thenReturn(Some("Andalusia"))
-    Mockito.when(tagServiceMock.nameForOsmId(almeria, None)).thenReturn(Some("Almeria"))
-    Mockito.when(tagServiceMock.nameForOsmId(yahooAlmeria, None)).thenReturn(Some("Almeria"))
-    Mockito.when(tagServiceMock.tagsFor(any[OsmId])).thenReturn(None)
+    Mockito.when(tagServiceMock.nameForOsmId(spain, point, None)).thenReturn(Some("Spain"))
+    Mockito.when(tagServiceMock.nameForOsmId(andalusia, point, None)).thenReturn(Some("Andalusia"))
+    Mockito.when(tagServiceMock.nameForOsmId(almeria, point, None)).thenReturn(Some("Almeria"))
+    Mockito.when(tagServiceMock.nameForOsmId(yahooAlmeria, point, None)).thenReturn(Some("Almeria"))
+    Mockito.when(tagServiceMock.tagsFor(any[OsmId], Matchers.eq(point))).thenReturn(None)
 
     val namingService = new NaiveNamingService(tagServiceMock)
 
-    val name = namingService.nameFor(paths)
+    val name = namingService.nameFor(paths, point)
 
     name must equalTo("Almeria, Andalusia, Spain")
   }
 
- /*
- "When naming an area with overlapping relations prefer localised name tags" in {
-   //https://www.openstreetmap.org/relation/51477
-   //https://www.openstreetmap.org/relation/4108738#map=7/51.351/10.454
-   //Germany, not 'Deutschland, Germany'
-   failure
- }
- */
+  /*
+  "When naming an area with overlapping relations prefer localised name tags" in {
+    //https://www.openstreetmap.org/relation/51477
+    //https://www.openstreetmap.org/relation/4108738#map=7/51.351/10.454
+    //Germany, not 'Deutschland, Germany'
+    failure
+  }
+  */
 
 
   /*

--- a/osm-jigsaw-parser/README.md
+++ b/osm-jigsaw-parser/README.md
@@ -134,3 +134,36 @@ Requests from a given user are likely to be for areas which are close to each ot
 Segmenting the graph into tiles which cover small areas of the graph should allow us to service occasional users without having to retain the entire graph in memory.
 
 We're happy to accept duplication of data between tiles to achieve this smaller memory footprint.
+
+Untiled disk usage:
+```
+13G Jul 12 11:29 planet-230703.areas.pbf
+185M Jul 15 17:44 planet-230703.graphv2.pbf
+2.3G Jul 13 11:44 planet-230703.tags.pbf
+```
+
+Tilted disk usage:
+```
+du -h
+83G .
+```
+
+```
+-rw-rw-r-- 1 tony tony   4795094 Jul 22 09:06 planet-230703.areas-dws.pbf
+-rw-rw-r-- 1 tony tony   4795094 Jul 22 09:04 planet-230703.areas-dwt.pbf
+-rw-rw-r-- 1 tony tony   4795094 Jul 22 09:04 planet-230703.areas-dwu.pbf
+-rw-rw-r-- 1 tony tony   4795094 Jul 22 09:05 planet-230703.areas-dwv.pbf
+```
+
+```
+sha256sum planet-230703.areas-dws.pbf planet-230703.areas-dwt.pbf
+94dcd56575779c1a36e53a5f6364dcc6650269309a2b15bea4495f52535ef944  planet-230703.areas-dws.pbf
+94dcd56575779c1a36e53a5f6364dcc6650269309a2b15bea4495f52535ef944  planet-230703.areas-dwt.pbf
+```
+
+```
+rdfind .
+
+It seems like you have 40374 files that are not unique
+Totally, 12 GiB can be reduced.
+```

--- a/osm-jigsaw-parser/go.bash
+++ b/osm-jigsaw-parser/go.bash
@@ -6,7 +6,7 @@ set -e
 mkdir -p $input
 
 jarfile="osm-jigsaw-parser-assembly-1.0.jar"
-java -jar $jarfile -s boundaries $input
+#java -jar $jarfile -s boundaries $input
 #java -Xmx8G -jar $jarfile -s extract $input
 #java -Xmx8G -jar $jarfile -s areaways $input
 #java -Xmx8G -jar $jarfile -s areas $input
@@ -14,3 +14,4 @@ java -jar $jarfile -s boundaries $input
 #java -jar $jarfile -s tags $input 
 #java -jar $jarfile -s flip $input
 
+java -jar $jarfile -s tile $input

--- a/osm-jigsaw-parser/src/main/scala/Main.scala
+++ b/osm-jigsaw-parser/src/main/scala/Main.scala
@@ -227,7 +227,7 @@ object Main extends EntityRendering with Logging with PolygonBuilding
     // Generate some tile shapes
     val tiles = new TileGenerator().generateTiles(2)
 
-    tiles.foreach { t =>
+    tiles.par.foreach { t =>
       // For each tile filter walk the graph and filter for all areas which intersect the tile
       val topLeft = (t.boundingBox.getNorthEastCorner.getLatitude, t.boundingBox.getSouthWestCorner.getLongitude)
       val bottomRight = (t.boundingBox.getSouthWestCorner.getLatitude, t.boundingBox.getNorthEastCorner.getLongitude)

--- a/osm-jigsaw-parser/src/main/scala/Main.scala
+++ b/osm-jigsaw-parser/src/main/scala/Main.scala
@@ -46,8 +46,8 @@ object Main extends EntityRendering with Logging with PolygonBuilding
         val relationIds = cmd.getArgList.get(2).split(",").map(s => s.toLong).toSeq
         extractRelations(inputFilepath, cmd.getArgList.get(1), relationIds)
       }
-      case "flip" =>
-        flipGraph(inputFilepath)
+      case "flip" => flipGraph(inputFilepath)
+      case "tile" => tileGraph(inputFilepath)
       case _ => logger.info("Unknown step") // TODO exit code
     }
   }
@@ -150,7 +150,7 @@ object Main extends EntityRendering with Logging with PolygonBuilding
     val nodes = mutable.Map[Long, FlippedGraphNode]()
 
     val progressMessage: (Long, scala.Option[Long], Long, Double) => String = (i: Long, total: scala.Option[Long], delta: Long, rate: Double) => {
-        i + " / Unique nodes: " + nodes.size
+      i + " / Unique nodes: " + nodes.size
     }
 
     var root: FlippedGraphNode = null
@@ -212,6 +212,17 @@ object Main extends EntityRendering with Logging with PolygonBuilding
     output.close()
 
     logger.info("Done")
+  }
+
+  def tileGraph(extractName: String): Unit = {
+    // Read the entire graph into memory
+    val graphInput = new BufferedInputStream(new FileInputStream(new File(graphV2File(extractName))))
+    throw new RuntimeException("Not implemented")
+
+    // Generate some tile shapes
+    // For each file filter walk the graph and filter for all areas which intersect the tile
+    // Output these; probably as a graph with the tile as the root node.
+    // Output area and tags files for this subset of the graph.
   }
 
 }

--- a/osm-jigsaw-parser/src/main/scala/Main.scala
+++ b/osm-jigsaw-parser/src/main/scala/Main.scala
@@ -1,4 +1,6 @@
 import areas.AreaComparison
+import com.esri.core.geometry.Geometry.GeometryAccelerationDegree
+import com.esri.core.geometry.{Operator, OperatorContains}
 import graph.GraphReader
 import graphing.EntitiesToGraph
 import input._
@@ -232,6 +234,8 @@ object Main extends EntityRendering with Logging with PolygonBuilding
       val topLeft = (t.boundingBox.getNorthEastCorner.getLatitude, t.boundingBox.getSouthWestCorner.getLongitude)
       val bottomRight = (t.boundingBox.getSouthWestCorner.getLatitude, t.boundingBox.getNorthEastCorner.getLongitude)
       val tilePolygon = makePolygonD(topLeft, bottomRight)
+      OperatorContains.local().accelerateGeometry(tilePolygon, sr, GeometryAccelerationDegree.enumMedium)
+
       val tileArea = new Area(-1, tilePolygon, boundingBoxFor(tilePolygon), area = 0.0)
 
       // Create a new graph root for this segment
@@ -301,6 +305,7 @@ object Main extends EntityRendering with Logging with PolygonBuilding
         tileGraphOutput.close()
       }
 
+      Operator.deaccelerateGeometry(tilePolygon)
     }
     // Output these; probably as a graph with the tile as the root node.
     // Output area and tags files for this subset of the graph.

--- a/osm-jigsaw-parser/src/main/scala/areas/AreaComparision.scala
+++ b/osm-jigsaw-parser/src/main/scala/areas/AreaComparision.scala
@@ -1,6 +1,6 @@
 package areas
 
-import com.esri.core.geometry.{OperatorContains, Polygon, SpatialReference}
+import com.esri.core.geometry.{OperatorContains, OperatorIntersects, Polygon, SpatialReference}
 import model.Area
 
 trait AreaComparison {
@@ -11,6 +11,10 @@ trait AreaComparison {
 
   def areaContains(a: Area, b: Area): Boolean = {
     OperatorContains.local().execute(a.polygon, b.polygon, sr, null)
+  }
+
+  def areasIntersect(a: Area, b: Area): Boolean = {
+    OperatorIntersects.local().execute(a.polygon, b.polygon, sr, null)
   }
 
   def areaSame(a: Area, b: Area): Boolean = {

--- a/osm-jigsaw-parser/src/main/scala/model/Tile.scala
+++ b/osm-jigsaw-parser/src/main/scala/model/Tile.scala
@@ -1,0 +1,5 @@
+package model
+
+import ch.hsr.geohash.BoundingBox
+
+case class Tile(geohash: String, boundingBox: BoundingBox)

--- a/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
+++ b/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
@@ -4,20 +4,21 @@ import steps.Segment
 
 trait OutputFiles {
 
-  def areasFilePath(extractName: String): String = {
-    outputFolderFor(extractName) + "/" + extractName + ".areas.pbf"
+  def areasFilePath(extractName: String, segment: Option[String] = None): String = {
+    outputFolderFor(extractName) + "/" + extractName + ".areas" + segment.map(s => "-" + s).getOrElse("") + ".pbf"
   }
 
+  @Deprecated
   def segmentGraphFile(extractName: String, segment: Segment) = {
     outputFolderFor(extractName) + "/" + extractName + ".graph." + segment.geohash.toBase32 + ".pbf"
   }
 
   def graphFile(extractName: String) = {
-      extractName + ".graph" + ".pbf"
+    extractName + ".graph" + ".pbf"
   }
 
-  def graphV2File(extractName: String) = {
-    outputFolderFor(extractName) + "/" + extractName + ".graphv2" + ".pbf"
+  def graphV2File(extractName: String, segment: Option[String] = None) = {
+    outputFolderFor(extractName) + "/" + extractName + ".graphv2" + segment.map(s => "-" + s).getOrElse("") + ".pbf"
   }
 
   def tagsFilePath(extractName: String): String = {
@@ -25,7 +26,7 @@ trait OutputFiles {
   }
 
   def outputFolderFor(extractName: String): String = {
-      extractName
+    extractName
   }
 
 }

--- a/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
+++ b/osm-jigsaw-parser/src/main/scala/output/OutputFiles.scala
@@ -21,8 +21,8 @@ trait OutputFiles {
     outputFolderFor(extractName) + "/" + extractName + ".graphv2" + segment.map(s => "-" + s).getOrElse("") + ".pbf"
   }
 
-  def tagsFilePath(extractName: String): String = {
-    outputFolderFor(extractName) + "/" + extractName + ".tags.pbf"
+  def tagsFilePath(extractName: String, segment: Option[String] = None): String = {
+    outputFolderFor(extractName) + "/" + extractName + ".tags" + segment.map(s => "-" + s).getOrElse("") + ".pbf"
   }
 
   def outputFolderFor(extractName: String): String = {

--- a/osm-jigsaw-parser/src/main/scala/tiles/GraphReader.scala
+++ b/osm-jigsaw-parser/src/main/scala/tiles/GraphReader.scala
@@ -1,0 +1,59 @@
+package graph
+
+import model.{Area, GraphNode}
+import org.apache.logging.log4j.scala.Logging
+import outputgraphnodev2.OutputGraphNodeV2
+import progress.ProgressCounter
+import resolving.{BoundingBox, PolygonBuilding}
+
+import java.io.InputStream
+import scala.collection.mutable
+
+class GraphReader extends Logging with PolygonBuilding with BoundingBox {
+
+  def loadGraph(graphInput: InputStream, areas: Seq[Area]): Option[GraphNode] = {
+    val tilePolygon = makePolygonD((-180, 90), (180, -90))
+
+    val planet = Area(id = -1L, polygon = tilePolygon, boundingBox = boundingBoxFor(tilePolygon), osmIds = mutable.ListBuffer[String](), area = 0.0) // TODO If we need this root node then it should be in the graph and areas file
+    val areasMap = areas.map(a => (a.id, a)).toMap + (planet.id -> planet)
+
+    val nodes = mutable.Map[Long, GraphNode]()
+
+    def toGraphNode(ogn: OutputGraphNodeV2): GraphNode = {
+      val area = areasMap(ogn.area)
+      // Map the children; leaf nodes appear first in the input file so will always have been created before been referenced
+      val children = mutable.Set(ogn.children.map { childId => // TODO really needs to be mutable or not?
+        nodes(childId)
+      }.toSet).flatten
+      GraphNode(area = area, children = children)
+    }
+
+    try {
+      val counterSecond = new ProgressCounter(step = 100, label = Some("Reading graph"))
+      var ok = true
+
+      var root: GraphNode = null
+      while (ok) {
+        counterSecond.withProgress {
+          ok = OutputGraphNodeV2.parseDelimitedFrom(graphInput).map { oa =>
+            val node = toGraphNode(oa)
+            root = node
+            nodes.put(node.area.id, node)
+            node
+          }.nonEmpty
+        }
+      }
+      graphInput.close()
+
+      logger.info("Finished reading")
+      logger.info("Head node is: " + root.area.id)
+      Some(root)
+
+    } catch {
+      case e: Exception =>
+        logger.error("Error: " + e)
+        throw e
+    }
+  }
+
+}

--- a/osm-jigsaw-parser/src/main/scala/tiles/TileGenerator.scala
+++ b/osm-jigsaw-parser/src/main/scala/tiles/TileGenerator.scala
@@ -1,0 +1,34 @@
+package tiles
+
+import ch.hsr.geohash.GeoHash
+import ch.hsr.geohash.util.TwoGeoHashBoundingBox
+import model.Tile
+import org.apache.logging.log4j.scala.Logging
+
+import scala.collection.mutable
+import scala.util.control.Breaks._
+
+class TileGenerator extends Logging {
+
+  def generateTiles(resolution: Int): Seq[Tile] = {
+    val planetBoundingBox = new ch.hsr.geohash.BoundingBox(-90, 90, -180, 180) // causes an infinite loop so need breakage below =(
+    val tt = TwoGeoHashBoundingBox.withCharacterPrecision(planetBoundingBox, resolution)
+    val i = new ch.hsr.geohash.util.BoundingBoxGeoHashIterator(tt)
+
+    val uniqueHashes = mutable.Set[GeoHash]()
+    breakable {
+      while (i.hasNext) {
+        val hash = i.next()
+        if (uniqueHashes.contains(hash)) {
+          break
+        }
+        uniqueHashes += hash
+      }
+    }
+
+    uniqueHashes.map { h =>
+      Tile(h.toBase32, h.getBoundingBox)
+    }.toSeq
+  }
+
+}

--- a/osm-jigsaw-parser/src/test/scala/resolving/OutlineBuilderSpec.scala
+++ b/osm-jigsaw-parser/src/test/scala/resolving/OutlineBuilderSpec.scala
@@ -2,11 +2,11 @@ package resolving
 
 import input.TestValues
 import model.EntityRendering
-import org.openstreetmap.osmosis.core.domain.v0_6.{Node, Relation, Way}
+import org.openstreetmap.osmosis.core.domain.v0_6.{Relation, Way}
 import org.scalatest.FlatSpec
 
-import scala.collection.mutable
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 class OutlineBuilderSpec extends FlatSpec with TestValues with LoadTestEntities with EntityRendering {
 

--- a/osm-jigsaw-parser/src/test/scala/tiles/TileGeneratorSpec.scala
+++ b/osm-jigsaw-parser/src/test/scala/tiles/TileGeneratorSpec.scala
@@ -1,0 +1,16 @@
+package tiles
+
+import org.scalatest.FlatSpec
+
+class TileGeneratorSpec extends FlatSpec {
+
+  private val tileGenerator = new TileGenerator()
+
+  "TileGenerator" should
+    "generate a tiles based on geohashes" in {
+    assert(tileGenerator.generateTiles(1).size == 32)
+    assert(tileGenerator.generateTiles(2).size == 1024)
+    assert(tileGenerator.generateTiles(4).size == 1048576)
+  }
+
+}

--- a/osm-jigsaw-parser/src/test/scala/tiles/TileGeneratorSpec.scala
+++ b/osm-jigsaw-parser/src/test/scala/tiles/TileGeneratorSpec.scala
@@ -10,7 +10,7 @@ class TileGeneratorSpec extends FlatSpec {
     "generate a tiles based on geohashes" in {
     assert(tileGenerator.generateTiles(1).size == 32)
     assert(tileGenerator.generateTiles(2).size == 1024)
-    assert(tileGenerator.generateTiles(4).size == 1048576)
+    assert(tileGenerator.generateTiles(3).size == 32768)
   }
 
 }

--- a/osm-jigsaw-viewer/app/controllers/Application.scala
+++ b/osm-jigsaw-viewer/app/controllers/Application.scala
@@ -36,10 +36,10 @@ class Application @Inject()(configuration: Configuration, ws: WSClient, cc: Cont
       }
 
       val eventualAreaBoundingBox = lastNode.map { _ =>
-        ws.url(Url.parse(apiUrl + "/points").addParam(
-          "q", q).addParam(
-          "lat", lat.toString).addParam(
-          "lon", lon.toString).toString).get.map { psr =>
+        ws.url(Url.parse(apiUrl + "/points").
+          addParam("q", q).
+          addParam("lat", lat.toString).
+          addParam("lon", lon.toString).toString).get.map { psr =>
           implicit val pr = Json.reads[Point]
           val points = Json.parse(psr.body).as[Seq[Point]]
           val b: (Double, Double, Double, Double) = boundingBoxFor(points)
@@ -61,7 +61,9 @@ class Application @Inject()(configuration: Configuration, ws: WSClient, cc: Cont
       val eventualTagsForLastNode: Future[Map[String, String]] = lastNode.flatMap { ln =>
         ln.entities.headOption.map { e =>
           val osmId = e.osmId
-          ws.url(Url.parse(apiUrl + "/tags").addParam("osm_id", osmId).toString).get.map { r =>
+          ws.url(Url.parse(apiUrl + "/tags").addParam("osm_id", osmId).
+            addParam("lat", lat.toString).
+            addParam("lon", lon.toString).toString).get.map { r =>
             Json.parse(r.body).as[Map[String, JsValue]].map { i =>
               (i._1, i._2.as[String])
             }


### PR DESCRIPTION
The API can read the entire planet graph and serve requests if given 64Gb of heap.
This isn't a completely out of order amount of memory of this service was been used constantly.

Because it isn't, we want to optimise for a small standing memory requirement.
Splitting the graph into tiles means we don't need to load all of the data into memory all the time.

Trades disk space (which we have) and cold  first request response times for smaller memory footprint.

Allows the API to serve whole planet requests to infrequent users from a 4Gb heap